### PR TITLE
Define classes as "var", not "const"

### DIFF
--- a/manager.js
+++ b/manager.js
@@ -25,7 +25,7 @@ const Lang = imports.lang;
 const SOUNDS_BASE_PATH = Extension.dir.get_child('sounds').get_path();
 const DB_PATH = GLib.build_filenamev([SOUNDS_BASE_PATH, "database.json"]);
 
-const Manager = new Lang.Class({
+var Manager = new Lang.Class({
     Name: 'Manager',
     Extends: GObject.Object,
     Signals: {

--- a/sound.js
+++ b/sound.js
@@ -29,7 +29,7 @@ const St = imports.gi.St;
 
 const DEFAULT_VOLUME = 0.5;
 
-const SoundBox = new Lang.Class({
+var SoundBox = new Lang.Class({
     Name: 'SoundBox',
     Extends: St.BoxLayout,
     Properties: {


### PR DESCRIPTION
To avoid this warning:
"
Some code accessed the property 'SoundBox' on the module 'sound'.
That property was defined with 'let' or 'const' inside the module.
This was previously supported, but is not correct according to the ES6 standard.
Any symbols to be exported from a module must be defined with 'var'.
The property access will work as previously for the time being, but please fix your code anyway.
"