### PR TITLE
metadata.json: Mark compatible with GNOME 41

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,5 +3,5 @@
   "description": "Improve focus and increase your productive by listening to different sounds",
   "uuid": "focusli@armonge.info",
   "url": "https://github.com/armonge/gnome-shell-extension-focusli",
-  "shell-version": ["3.34", "3.36", "40"]
+  "shell-version": ["3.34", "3.36", "40", "41"]
 }


### PR DESCRIPTION
Focusli seems to work fine on GNOME 41.

I've tested this on Arch Linux as of 2022-01-09 with GNOME version 41.2.